### PR TITLE
UX improvements

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,7 +42,7 @@ export const overrides: TLUiOverrides = {
 			toolbar.splice(highlighterIndex, 1)
 			toolbar.splice(3, 0, highlighterItem)
 		}
-		toolbar.splice(4, 0, toolbarItem(tools.liveImage))
+		toolbar.splice(2, 0, toolbarItem(tools.liveImage))
 		return toolbar
 	},
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { LiveImageShape, LiveImageShapeUtil } from '@/components/LiveImageShapeUtil'
 import * as fal from '@fal-ai/serverless-client'
-import { Editor, Tldraw, useEditor } from '@tldraw/tldraw'
+import { Editor, TLUiMenuGroup, TLUiOverrides, Tldraw, menuItem, toolbarItem, useEditor } from '@tldraw/tldraw'
 import { useEffect } from 'react'
 import { LiveImageTool, MakeLiveButton } from '../components/LiveImageTool'
 
@@ -11,6 +11,35 @@ fal.config({
 		targetUrl: '/api/fal/proxy',
 	}),
 })
+
+export const overrides: TLUiOverrides = {
+	tools(editor, tools) {
+		tools.liveImage = {
+			id: 'live-image',
+			icon: 'tool-frame',
+			label: 'Frame',
+			kbd: 'f',
+			readonlyOk: false,
+			onSelect: () => {
+				editor.setCurrentTool('live-image')
+			},
+		}
+		return tools
+	},
+	toolbar(_app, toolbar, { tools }) {
+		const frameIndex = toolbar.findIndex((item) => item.id === 'frame')
+		if (frameIndex !== -1) toolbar.splice(frameIndex, 1)
+		const highlighterIndex = toolbar.findIndex((item) => item.id === 'highlight')
+		if (highlighterIndex !== -1) {
+			const highlighterItem = toolbar[highlighterIndex]
+			toolbar.splice(highlighterIndex, 1)
+			toolbar.splice(3, 0, highlighterItem)
+		}
+		toolbar.splice(4, 0, toolbarItem(tools.liveImage))
+		return toolbar
+	},
+}
+
 
 const shapeUtils = [LiveImageShapeUtil]
 const tools = [LiveImageTool]
@@ -51,6 +80,7 @@ export default function Home() {
 					shapeUtils={shapeUtils}
 					tools={tools}
 					shareZone={<MakeLiveButton />}
+					overrides={overrides}
 				>
 					<SneakySideEffects />
 				</Tldraw>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,14 @@
 
 import { LiveImageShape, LiveImageShapeUtil } from '@/components/LiveImageShapeUtil'
 import * as fal from '@fal-ai/serverless-client'
-import { Editor, TLUiMenuGroup, TLUiOverrides, Tldraw, menuItem, toolbarItem, useEditor } from '@tldraw/tldraw'
+import {
+	DefaultSizeStyle,
+	Editor,
+	TLUiOverrides,
+	Tldraw,
+	toolbarItem,
+	useEditor,
+} from '@tldraw/tldraw'
 import { useEffect } from 'react'
 import { LiveImageTool, MakeLiveButton } from '../components/LiveImageTool'
 
@@ -40,7 +47,6 @@ export const overrides: TLUiOverrides = {
 	},
 }
 
-
 const shapeUtils = [LiveImageShapeUtil]
 const tools = [LiveImageTool]
 
@@ -69,6 +75,8 @@ export default function Home() {
 				},
 			})
 		}
+
+		editor.setStyleForNextShapes(DefaultSizeStyle, 'xl', { ephemeral: true })
 	}
 
 	return (

--- a/src/components/FrameLabelInput.tsx
+++ b/src/components/FrameLabelInput.tsx
@@ -1,9 +1,4 @@
-import {
-	TLFrameShape,
-	TLShapeId,
-	stopEventPropagation,
-	useEditor,
-} from '@tldraw/editor'
+import { TLFrameShape, TLShapeId, stopEventPropagation, useEditor } from '@tldraw/editor'
 import { forwardRef, useCallback } from 'react'
 
 export const FrameLabelInput = forwardRef<
@@ -72,9 +67,7 @@ export const FrameLabelInput = forwardRef<
 	)
 
 	return (
-		<div
-			className={`tl-frame-label ${isEditing ? 'tl-frame-label__editing' : ''}`}
-		>
+		<div className={`tl-frame-label ${isEditing ? 'tl-frame-label__editing' : ''}`}>
 			<input
 				className="tl-frame-name-input"
 				ref={ref}
@@ -85,7 +78,7 @@ export const FrameLabelInput = forwardRef<
 				onBlur={handleBlur}
 				onChange={handleChange}
 			/>
-			{defaultEmptyAs(name, 'Double click prompt to edit it') + String.fromCharCode(8203)}
+			{defaultEmptyAs(name, 'Double click prompt to edit') + String.fromCharCode(8203)}
 		</div>
 	)
 })

--- a/src/components/FrameLabelInput.tsx
+++ b/src/components/FrameLabelInput.tsx
@@ -85,7 +85,7 @@ export const FrameLabelInput = forwardRef<
 				onBlur={handleBlur}
 				onChange={handleChange}
 			/>
-			{defaultEmptyAs(name, 'Frame') + String.fromCharCode(8203)}
+			{defaultEmptyAs(name, 'Double click prompt to edit it') + String.fromCharCode(8203)}
 		</div>
 	)
 })

--- a/src/components/FrameLabelInput.tsx
+++ b/src/components/FrameLabelInput.tsx
@@ -77,6 +77,7 @@ export const FrameLabelInput = forwardRef<
 				onKeyDown={handleKeyDown}
 				onBlur={handleBlur}
 				onChange={handleChange}
+				onPointerDown={stopEventPropagation}
 			/>
 			{defaultEmptyAs(name, 'Double click prompt to edit') + String.fromCharCode(8203)}
 		</div>

--- a/src/components/LiveImageShapeUtil.tsx
+++ b/src/components/LiveImageShapeUtil.tsx
@@ -65,7 +65,7 @@ export class LiveImageShapeUtil extends ShapeUtil<LiveImageShape> {
 		return {
 			w: 512,
 			h: 512,
-			name: 'a city skyline',
+			name: '',
 		}
 	}
 


### PR DESCRIPTION
This PR makes some UX changes.

- The highlighter tool is placed earlier on in the toolbar (so that it's visible - not in the overflow menu).
- The live image tool is placed on the toolbar (so that it's visible - not in the overflow menu). Replaces the frame tool.
- The size style defaults to XL on load, as it works better with draw fast.
- The 'f' keyboard shortcut now selects the live image tool.
- The 'draw fast' button now creates a frame with no prompt.
- Frames with no prompt read 'double click prompt to edit'.
- Fixed not being able to click on the prompt input when editing.

<img width="631" alt="image" src="https://github.com/tldraw/draw-fast/assets/15892272/95874e31-9e6a-4411-8cda-66f8891097e2">


<img width="498" alt="image" src="https://github.com/tldraw/draw-fast/assets/15892272/e04bd155-b4a9-456f-a518-4e07fdbdb3cb">
