### PR TITLE
Add chat prototype with internal hyperlinks and fork navigation

### DIFF
--- a/src/app/chat/chat.css
+++ b/src/app/chat/chat.css
@@ -1,0 +1,539 @@
+/* ============== Chat App Layout ============== */
+
+.chat-app {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #e0e0e0;
+  background: #1a1a2e;
+}
+
+/* ============== Sidebar ============== */
+
+.chat-sidebar {
+  width: 280px;
+  min-width: 280px;
+  background: #16213e;
+  border-right: 1px solid #0f3460;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid #0f3460;
+}
+
+.sidebar-header h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #e94560;
+}
+
+.new-chat-btn {
+  all: unset;
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: #0f3460;
+  color: #e94560;
+  font-size: 18px;
+  font-weight: 600;
+  transition: background 0.15s;
+}
+
+.new-chat-btn:hover {
+  background: #e94560;
+  color: white;
+}
+
+.sidebar-tree {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.sidebar-tree::-webkit-scrollbar {
+  width: 4px;
+}
+
+.sidebar-tree::-webkit-scrollbar-thumb {
+  background: #0f3460;
+  border-radius: 2px;
+}
+
+.sidebar-footer {
+  padding: 10px 16px;
+  border-top: 1px solid #0f3460;
+  font-size: 12px;
+  color: #555;
+}
+
+/* Tree Nodes */
+
+.tree-node {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  margin: 1px 4px;
+  transition: background 0.1s;
+}
+
+.tree-node:hover {
+  background: rgba(233, 69, 96, 0.1);
+}
+
+.tree-node--active {
+  background: rgba(233, 69, 96, 0.2) !important;
+}
+
+.tree-toggle {
+  all: unset;
+  cursor: pointer;
+  width: 16px;
+  font-size: 11px;
+  color: #888;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.tree-label {
+  all: unset;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  padding: 3px 0;
+}
+
+.tree-icon {
+  flex-shrink: 0;
+  font-size: 10px;
+  color: #e94560;
+}
+
+.tree-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tree-delete {
+  all: unset;
+  cursor: pointer;
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: 14px;
+  color: #666;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.tree-node:hover .tree-delete {
+  opacity: 1;
+}
+
+.tree-delete:hover {
+  color: #e94560;
+  background: rgba(233, 69, 96, 0.15);
+}
+
+/* ============== Main Chat Area ============== */
+
+.chat-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.chat-feed-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.chat-feed-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #555;
+  font-size: 16px;
+}
+
+/* Breadcrumbs */
+
+.chat-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 20px;
+  border-bottom: 1px solid #0f3460;
+  background: #16213e;
+  font-size: 12px;
+  flex-wrap: wrap;
+  min-height: 38px;
+}
+
+.breadcrumb-sep {
+  color: #444;
+}
+
+.breadcrumb-item {
+  all: unset;
+  cursor: pointer;
+  color: #7b8db8;
+  padding: 2px 6px;
+  border-radius: 3px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.breadcrumb-item:hover {
+  color: #e94560;
+  background: rgba(233, 69, 96, 0.1);
+}
+
+.breadcrumb-item--active {
+  color: #e0e0e0;
+  font-weight: 600;
+}
+
+/* Chat Title */
+
+.chat-title-bar {
+  padding: 12px 20px;
+  border-bottom: 1px solid #0f3460;
+  background: #1a1a2e;
+}
+
+.chat-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: default;
+}
+
+.chat-title-input {
+  all: unset;
+  font-size: 18px;
+  font-weight: 600;
+  color: #e0e0e0;
+  border-bottom: 2px solid #e94560;
+  padding-bottom: 2px;
+  width: 100%;
+}
+
+.chat-fork-badge {
+  font-size: 10px;
+  font-weight: 500;
+  background: #0f3460;
+  color: #e94560;
+  padding: 2px 8px;
+  border-radius: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.chat-fork-info {
+  font-size: 12px;
+  color: #7b8db8;
+  margin-top: 4px;
+  display: block;
+}
+
+/* Chat Feed */
+
+.chat-feed {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.chat-feed::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-feed::-webkit-scrollbar-thumb {
+  background: #0f3460;
+  border-radius: 3px;
+}
+
+.chat-empty {
+  color: #555;
+  text-align: center;
+  margin-top: 40px;
+  font-size: 14px;
+}
+
+/* Messages */
+
+.chat-message {
+  padding: 10px 14px;
+  border-radius: 8px;
+  position: relative;
+}
+
+.chat-message--user {
+  background: rgba(15, 52, 96, 0.5);
+  border-left: 3px solid #0f3460;
+}
+
+.chat-message--assistant {
+  background: rgba(233, 69, 96, 0.08);
+  border-left: 3px solid #e94560;
+}
+
+.chat-message--system {
+  background: rgba(100, 100, 255, 0.08);
+  border-left: 3px solid #5555aa;
+  font-size: 13px;
+}
+
+.message-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+
+.message-role {
+  font-weight: 600;
+  color: #aaa;
+}
+
+.message-time {
+  color: #555;
+}
+
+.fork-btn {
+  all: unset;
+  cursor: pointer;
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  font-size: 16px;
+  color: #555;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+}
+
+.chat-message:hover .fork-btn {
+  opacity: 1;
+}
+
+.fork-btn:hover {
+  color: #e94560;
+  background: rgba(233, 69, 96, 0.15);
+}
+
+.message-content {
+  font-size: 14px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Internal Links */
+
+.internal-link {
+  all: unset;
+  cursor: pointer;
+  color: #e94560;
+  font-weight: 500;
+  text-decoration: none;
+  border-bottom: 1px dashed #e94560;
+  padding: 0 2px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.internal-link:hover {
+  background: rgba(233, 69, 96, 0.15);
+  border-bottom-style: solid;
+}
+
+.internal-link--dead {
+  color: #666;
+  border-color: #444;
+  cursor: not-allowed;
+  text-decoration: line-through;
+}
+
+/* Fork Dialog */
+
+.fork-dialog {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+  padding: 8px;
+  background: #16213e;
+  border-radius: 6px;
+  border: 1px solid #0f3460;
+}
+
+.fork-input {
+  all: unset;
+  flex: 1;
+  font-size: 13px;
+  padding: 6px 10px;
+  background: #1a1a2e;
+  border: 1px solid #0f3460;
+  border-radius: 4px;
+  color: #e0e0e0;
+}
+
+.fork-input::placeholder {
+  color: #555;
+}
+
+.fork-confirm {
+  all: unset;
+  cursor: pointer;
+  padding: 6px 12px;
+  background: #e94560;
+  color: white;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background 0.15s;
+}
+
+.fork-confirm:hover {
+  background: #c73753;
+}
+
+.fork-cancel {
+  all: unset;
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #888;
+  border-radius: 4px;
+}
+
+.fork-cancel:hover {
+  color: #e94560;
+}
+
+/* Fork Indicators */
+
+.fork-indicator {
+  all: unset;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  margin-right: 6px;
+  padding: 3px 10px;
+  font-size: 11px;
+  color: #e94560;
+  background: rgba(233, 69, 96, 0.08);
+  border: 1px solid rgba(233, 69, 96, 0.2);
+  border-radius: 12px;
+  transition: background 0.15s;
+}
+
+.fork-indicator:hover {
+  background: rgba(233, 69, 96, 0.2);
+}
+
+/* ============== Chat Input ============== */
+
+.chat-input-container {
+  display: flex;
+  gap: 10px;
+  padding: 14px 20px;
+  border-top: 1px solid #0f3460;
+  background: #16213e;
+  align-items: flex-end;
+}
+
+.chat-input {
+  all: unset;
+  flex: 1;
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 10px 14px;
+  background: #1a1a2e;
+  border: 1px solid #0f3460;
+  border-radius: 8px;
+  color: #e0e0e0;
+  resize: none;
+  min-height: 20px;
+  max-height: 120px;
+  font-family: inherit;
+}
+
+.chat-input::placeholder {
+  color: #555;
+}
+
+.chat-input:focus {
+  border-color: #e94560;
+  outline: none;
+}
+
+.chat-send-btn {
+  all: unset;
+  cursor: pointer;
+  padding: 10px 20px;
+  background: #e94560;
+  color: white;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  transition: background 0.15s;
+  white-space: nowrap;
+}
+
+.chat-send-btn:hover {
+  background: #c73753;
+}
+
+/* ============== Responsive ============== */
+
+@media (max-width: 768px) {
+  .chat-sidebar {
+    width: 200px;
+    min-width: 200px;
+  }
+}

--- a/src/app/chat/chat.css
+++ b/src/app/chat/chat.css
@@ -6,17 +6,17 @@
   width: 100vw;
   overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  color: #e0e0e0;
-  background: #1a1a2e;
+  color: #1a1a1a;
+  background: #fff;
 }
 
 /* ============== Sidebar ============== */
 
 .chat-sidebar {
-  width: 280px;
-  min-width: 280px;
-  background: #16213e;
-  border-right: 1px solid #0f3460;
+  width: 260px;
+  min-width: 260px;
+  background: #fafafa;
+  border-right: 1px solid #eee;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -26,58 +26,58 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px;
-  border-bottom: 1px solid #0f3460;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid #eee;
 }
 
 .sidebar-header h2 {
   margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: #e94560;
+  font-size: 13px;
+  font-weight: 500;
+  color: #999;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .new-chat-btn {
   all: unset;
   cursor: pointer;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 6px;
-  background: #0f3460;
-  color: #e94560;
+  color: #999;
   font-size: 18px;
-  font-weight: 600;
-  transition: background 0.15s;
+  transition: color 0.15s, background 0.15s;
 }
 
 .new-chat-btn:hover {
-  background: #e94560;
-  color: white;
+  color: #1a1a1a;
+  background: #eee;
 }
 
 .sidebar-tree {
   flex: 1;
   overflow-y: auto;
-  padding: 8px 0;
+  padding: 6px 0;
 }
 
 .sidebar-tree::-webkit-scrollbar {
-  width: 4px;
+  width: 3px;
 }
 
 .sidebar-tree::-webkit-scrollbar-thumb {
-  background: #0f3460;
+  background: #ddd;
   border-radius: 2px;
 }
 
 .sidebar-footer {
   padding: 10px 16px;
-  border-top: 1px solid #0f3460;
-  font-size: 12px;
-  color: #555;
+  border-top: 1px solid #eee;
+  font-size: 11px;
+  color: #bbb;
 }
 
 /* Tree Nodes */
@@ -86,26 +86,26 @@
   display: flex;
   align-items: center;
   gap: 2px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  margin: 1px 4px;
+  padding: 3px 8px;
+  border-radius: 6px;
+  margin: 1px 6px;
   transition: background 0.1s;
 }
 
 .tree-node:hover {
-  background: rgba(233, 69, 96, 0.1);
+  background: #f0f0f0;
 }
 
 .tree-node--active {
-  background: rgba(233, 69, 96, 0.2) !important;
+  background: #e8e8e8 !important;
 }
 
 .tree-toggle {
   all: unset;
   cursor: pointer;
-  width: 16px;
-  font-size: 11px;
-  color: #888;
+  width: 14px;
+  font-size: 10px;
+  color: #bbb;
   flex-shrink: 0;
   text-align: center;
 }
@@ -120,12 +120,18 @@
   min-width: 0;
   font-size: 13px;
   padding: 3px 0;
+  color: #444;
+}
+
+.tree-node--active .tree-label {
+  color: #1a1a1a;
+  font-weight: 500;
 }
 
 .tree-icon {
   flex-shrink: 0;
-  font-size: 10px;
-  color: #e94560;
+  font-size: 9px;
+  color: #bbb;
 }
 
 .tree-title {
@@ -144,7 +150,7 @@
   justify-content: center;
   border-radius: 4px;
   font-size: 14px;
-  color: #666;
+  color: #ccc;
   opacity: 0;
   transition: opacity 0.15s, color 0.15s;
 }
@@ -154,8 +160,7 @@
 }
 
 .tree-delete:hover {
-  color: #e94560;
-  background: rgba(233, 69, 96, 0.15);
+  color: #e55;
 }
 
 /* ============== Main Chat Area ============== */
@@ -181,8 +186,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #555;
-  font-size: 16px;
+  color: #ccc;
+  font-size: 15px;
 }
 
 /* Breadcrumbs */
@@ -191,43 +196,42 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 10px 20px;
-  border-bottom: 1px solid #0f3460;
-  background: #16213e;
+  padding: 8px 24px;
+  border-bottom: 1px solid #f0f0f0;
   font-size: 12px;
   flex-wrap: wrap;
-  min-height: 38px;
+  min-height: 34px;
 }
 
 .breadcrumb-sep {
-  color: #444;
+  color: #ddd;
+  font-size: 10px;
 }
 
 .breadcrumb-item {
   all: unset;
   cursor: pointer;
-  color: #7b8db8;
+  color: #aaa;
   padding: 2px 6px;
   border-radius: 3px;
   transition: color 0.15s, background 0.15s;
 }
 
 .breadcrumb-item:hover {
-  color: #e94560;
-  background: rgba(233, 69, 96, 0.1);
+  color: #1a1a1a;
+  background: #f5f5f5;
 }
 
 .breadcrumb-item--active {
-  color: #e0e0e0;
-  font-weight: 600;
+  color: #1a1a1a;
+  font-weight: 500;
 }
 
 /* Chat Title */
 
 .chat-title-bar {
-  padding: 12px 20px;
-  border-bottom: 1px solid #0f3460;
-  background: #1a1a2e;
+  padding: 14px 24px 10px;
+  border-bottom: 1px solid #f0f0f0;
 }
 
 .chat-title {
@@ -238,14 +242,15 @@
   align-items: center;
   gap: 10px;
   cursor: default;
+  color: #1a1a1a;
 }
 
 .chat-title-input {
   all: unset;
   font-size: 18px;
   font-weight: 600;
-  color: #e0e0e0;
-  border-bottom: 2px solid #e94560;
+  color: #1a1a1a;
+  border-bottom: 2px solid #1a1a1a;
   padding-bottom: 2px;
   width: 100%;
 }
@@ -253,8 +258,8 @@
 .chat-fork-badge {
   font-size: 10px;
   font-weight: 500;
-  background: #0f3460;
-  color: #e94560;
+  background: #f0f0f0;
+  color: #888;
   padding: 2px 8px;
   border-radius: 10px;
   text-transform: uppercase;
@@ -263,7 +268,7 @@
 
 .chat-fork-info {
   font-size: 12px;
-  color: #7b8db8;
+  color: #aaa;
   margin-top: 4px;
   display: block;
 }
@@ -273,25 +278,25 @@
 .chat-feed {
   flex: 1;
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: 20px 24px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .chat-feed::-webkit-scrollbar {
-  width: 6px;
+  width: 4px;
 }
 
 .chat-feed::-webkit-scrollbar-thumb {
-  background: #0f3460;
-  border-radius: 3px;
+  background: #e0e0e0;
+  border-radius: 2px;
 }
 
 .chat-empty {
-  color: #555;
+  color: #ccc;
   text-align: center;
-  margin-top: 40px;
+  margin-top: 60px;
   font-size: 14px;
 }
 
@@ -304,50 +309,48 @@
 }
 
 .chat-message--user {
-  background: rgba(15, 52, 96, 0.5);
-  border-left: 3px solid #0f3460;
+  background: #f8f8f8;
 }
 
 .chat-message--assistant {
-  background: rgba(233, 69, 96, 0.08);
-  border-left: 3px solid #e94560;
+  background: #fff;
 }
 
 .chat-message--system {
-  background: rgba(100, 100, 255, 0.08);
-  border-left: 3px solid #5555aa;
+  background: #fafafa;
   font-size: 13px;
+  border-left: 2px solid #e0e0e0;
 }
 
 .message-header {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
   font-size: 12px;
 }
 
 .message-role {
   font-weight: 600;
-  color: #aaa;
+  color: #888;
 }
 
 .message-time {
-  color: #555;
+  color: #ccc;
 }
 
 .fork-btn {
   all: unset;
   cursor: pointer;
   margin-left: auto;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   display: flex;
   align-items: center;
   justify-content: center;
   border-radius: 4px;
-  font-size: 16px;
-  color: #555;
+  font-size: 14px;
+  color: #ccc;
   opacity: 0;
   transition: opacity 0.15s, color 0.15s, background 0.15s;
 }
@@ -357,40 +360,110 @@
 }
 
 .fork-btn:hover {
-  color: #e94560;
-  background: rgba(233, 69, 96, 0.15);
+  color: #1a1a1a;
+  background: #f0f0f0;
 }
 
 .message-content {
   font-size: 14px;
-  line-height: 1.6;
+  line-height: 1.7;
   white-space: pre-wrap;
   word-break: break-word;
+  color: #333;
 }
 
-/* Internal Links */
+/* Internal Links (keyword-based) */
 
 .internal-link {
   all: unset;
   cursor: pointer;
-  color: #e94560;
+  color: #1a1a1a;
   font-weight: 500;
   text-decoration: none;
-  border-bottom: 1px dashed #e94560;
-  padding: 0 2px;
-  transition: color 0.15s, background 0.15s;
+  border-bottom: 1.5px solid #1a1a1a;
+  padding: 0 1px;
+  transition: background 0.15s;
 }
 
 .internal-link:hover {
-  background: rgba(233, 69, 96, 0.15);
-  border-bottom-style: solid;
+  background: #f0f0f0;
 }
 
 .internal-link--dead {
-  color: #666;
-  border-color: #444;
+  color: #bbb;
+  border-color: #ddd;
   cursor: not-allowed;
   text-decoration: line-through;
+}
+
+/* Selection Fork Popup */
+
+.selection-popup {
+  position: fixed;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 6px 5px 10px;
+  background: #1a1a1a;
+  border-radius: 10px;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.18);
+  animation: popup-in 0.12s ease-out;
+  max-width: 380px;
+}
+
+@keyframes popup-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.selection-popup-label {
+  color: #888;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100px;
+  flex-shrink: 0;
+}
+
+.selection-popup-input {
+  all: unset;
+  flex: 1;
+  font-size: 13px;
+  color: #fff;
+  min-width: 140px;
+  padding: 4px 0;
+}
+
+.selection-popup-input::placeholder {
+  color: #666;
+}
+
+.selection-popup-send {
+  all: unset;
+  cursor: pointer;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #333;
+  color: #fff;
+  border-radius: 6px;
+  font-size: 14px;
+  flex-shrink: 0;
+  transition: background 0.1s;
+}
+
+.selection-popup-send:hover {
+  background: #555;
 }
 
 /* Fork Dialog */
@@ -401,9 +474,9 @@
   gap: 6px;
   margin-top: 8px;
   padding: 8px;
-  background: #16213e;
-  border-radius: 6px;
-  border: 1px solid #0f3460;
+  background: #fafafa;
+  border-radius: 8px;
+  border: 1px solid #eee;
 }
 
 .fork-input {
@@ -411,30 +484,30 @@
   flex: 1;
   font-size: 13px;
   padding: 6px 10px;
-  background: #1a1a2e;
-  border: 1px solid #0f3460;
-  border-radius: 4px;
-  color: #e0e0e0;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  color: #1a1a1a;
 }
 
 .fork-input::placeholder {
-  color: #555;
+  color: #bbb;
 }
 
 .fork-confirm {
   all: unset;
   cursor: pointer;
-  padding: 6px 12px;
-  background: #e94560;
+  padding: 6px 14px;
+  background: #1a1a1a;
   color: white;
-  border-radius: 4px;
+  border-radius: 6px;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 500;
   transition: background 0.15s;
 }
 
 .fork-confirm:hover {
-  background: #c73753;
+  background: #333;
 }
 
 .fork-cancel {
@@ -445,12 +518,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #888;
+  color: #bbb;
   border-radius: 4px;
 }
 
 .fork-cancel:hover {
-  color: #e94560;
+  color: #1a1a1a;
 }
 
 /* Fork Indicators */
@@ -465,25 +538,26 @@
   margin-right: 6px;
   padding: 3px 10px;
   font-size: 11px;
-  color: #e94560;
-  background: rgba(233, 69, 96, 0.08);
-  border: 1px solid rgba(233, 69, 96, 0.2);
+  color: #888;
+  background: #f5f5f5;
+  border: 1px solid #eee;
   border-radius: 12px;
-  transition: background 0.15s;
+  transition: background 0.15s, color 0.15s;
 }
 
 .fork-indicator:hover {
-  background: rgba(233, 69, 96, 0.2);
+  background: #e8e8e8;
+  color: #1a1a1a;
 }
 
 /* ============== Chat Input ============== */
 
 .chat-input-container {
   display: flex;
-  gap: 10px;
-  padding: 14px 20px;
-  border-top: 1px solid #0f3460;
-  background: #16213e;
+  gap: 8px;
+  padding: 12px 24px 16px;
+  border-top: 1px solid #f0f0f0;
+  background: #fff;
   align-items: flex-end;
 }
 
@@ -493,10 +567,10 @@
   font-size: 14px;
   line-height: 1.5;
   padding: 10px 14px;
-  background: #1a1a2e;
-  border: 1px solid #0f3460;
-  border-radius: 8px;
-  color: #e0e0e0;
+  background: #fafafa;
+  border: 1px solid #e8e8e8;
+  border-radius: 10px;
+  color: #1a1a1a;
   resize: none;
   min-height: 20px;
   max-height: 120px;
@@ -504,29 +578,30 @@
 }
 
 .chat-input::placeholder {
-  color: #555;
+  color: #bbb;
 }
 
 .chat-input:focus {
-  border-color: #e94560;
+  border-color: #ccc;
   outline: none;
+  background: #fff;
 }
 
 .chat-send-btn {
   all: unset;
   cursor: pointer;
-  padding: 10px 20px;
-  background: #e94560;
+  padding: 10px 18px;
+  background: #1a1a1a;
   color: white;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
+  border-radius: 10px;
+  font-size: 13px;
+  font-weight: 500;
   transition: background 0.15s;
   white-space: nowrap;
 }
 
 .chat-send-btn:hover {
-  background: #c73753;
+  background: #333;
 }
 
 /* ============== Responsive ============== */

--- a/src/app/chat/layout.tsx
+++ b/src/app/chat/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Chat Links — Навигация по чатам',
+  description: 'Прототип чат-оболочки с внутренними гиперссылками',
+}
+
+export default function ChatLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <style>{`
+        html, body {
+          overflow: visible !important;
+          touch-action: auto !important;
+          overscroll-behavior: auto !important;
+        }
+      `}</style>
+      {children}
+    </>
+  )
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { ChatFeed } from '@/components/chat/ChatFeed'
+import { ChatInput } from '@/components/chat/ChatInput'
+import { ChatProvider } from '@/components/chat/ChatProvider'
+import { ChatSidebar } from '@/components/chat/ChatSidebar'
+import './chat.css'
+
+export default function ChatPage() {
+  return (
+    <ChatProvider>
+      <div className="chat-app">
+        <ChatSidebar />
+        <div className="chat-main">
+          <ChatFeed />
+          <ChatInput />
+        </div>
+      </div>
+    </ChatProvider>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,5 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
-
-const inter = Inter({ subsets: ['latin'] })
 
 const TITLE = 'draw fast • tldraw'
 const DESCRIPTION = 'Draw a picture (fast) with tldraw'
@@ -68,7 +65,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<html lang="en">
-			<body className={inter.className}>{children}</body>
+			<body style={{ fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif' }}>{children}</body>
 		</html>
 	)
 }

--- a/src/components/chat/ChatFeed.tsx
+++ b/src/components/chat/ChatFeed.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { getAncestors, parseLinks } from '@/lib/chatStore'
+import React, { useEffect, useRef, useState } from 'react'
+import { useChatContext } from './ChatProvider'
+
+function MessageContent({ content }: { content: string }) {
+  const { setCurrentChatId, store } = useChatContext()
+  const parts = parseLinks(content)
+
+  return (
+    <span>
+      {parts.map((part, i) => {
+        if (part.type === 'link' && part.chatId) {
+          const exists = !!store.chats[part.chatId]
+          return (
+            <button
+              key={i}
+              className={`internal-link ${!exists ? 'internal-link--dead' : ''}`}
+              onClick={() => exists && setCurrentChatId(part.chatId!)}
+              title={exists ? `Перейти: ${part.value}` : 'Чат удалён'}
+            >
+              🔗 {part.value}
+            </button>
+          )
+        }
+        return <span key={i}>{part.value}</span>
+      })}
+    </span>
+  )
+}
+
+function ForkDialog({
+  onConfirm,
+  onCancel,
+}: {
+  onConfirm: (title: string) => void
+  onCancel: () => void
+}) {
+  const [title, setTitle] = useState('')
+  return (
+    <div className="fork-dialog">
+      <input
+        className="fork-input"
+        type="text"
+        placeholder="Название ветки..."
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && title.trim()) onConfirm(title.trim())
+          if (e.key === 'Escape') onCancel()
+        }}
+        autoFocus
+      />
+      <button
+        className="fork-confirm"
+        onClick={() => title.trim() && onConfirm(title.trim())}
+      >
+        Создать
+      </button>
+      <button className="fork-cancel" onClick={onCancel}>
+        ✕
+      </button>
+    </div>
+  )
+}
+
+export function ChatFeed() {
+  const { store, currentChat, currentChatId, forkChat, setCurrentChatId, renameChat } =
+    useChatContext()
+  const feedRef = useRef<HTMLDivElement>(null)
+  const [forkingIndex, setForkingIndex] = useState<number | null>(null)
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [titleValue, setTitleValue] = useState('')
+
+  useEffect(() => {
+    if (feedRef.current) {
+      feedRef.current.scrollTop = feedRef.current.scrollHeight
+    }
+  }, [currentChat?.messages.length])
+
+  if (!currentChat) {
+    return <div className="chat-feed-empty">Выберите чат</div>
+  }
+
+  const ancestors = getAncestors(store, currentChatId)
+  const breadcrumbs = [...ancestors, currentChat]
+
+  return (
+    <div className="chat-feed-container">
+      {/* Breadcrumb navigation */}
+      <div className="chat-breadcrumbs">
+        {breadcrumbs.map((chat, i) => (
+          <React.Fragment key={chat.id}>
+            {i > 0 && <span className="breadcrumb-sep">→</span>}
+            <button
+              className={`breadcrumb-item ${
+                chat.id === currentChatId ? 'breadcrumb-item--active' : ''
+              }`}
+              onClick={() => setCurrentChatId(chat.id)}
+            >
+              {chat.title}
+            </button>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* Chat title */}
+      <div className="chat-title-bar">
+        {editingTitle ? (
+          <input
+            className="chat-title-input"
+            value={titleValue}
+            onChange={(e) => setTitleValue(e.target.value)}
+            onBlur={() => {
+              if (titleValue.trim()) renameChat(currentChatId, titleValue.trim())
+              setEditingTitle(false)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                if (titleValue.trim()) renameChat(currentChatId, titleValue.trim())
+                setEditingTitle(false)
+              }
+            }}
+            autoFocus
+          />
+        ) : (
+          <h1
+            className="chat-title"
+            onDoubleClick={() => {
+              setTitleValue(currentChat.title)
+              setEditingTitle(true)
+            }}
+          >
+            {currentChat.title}
+            {currentChat.parentId && (
+              <span className="chat-fork-badge">ветка</span>
+            )}
+          </h1>
+        )}
+        {currentChat.parentId && currentChat.parentMessageIndex !== null && (
+          <span className="chat-fork-info">
+            Форк от сообщения #{currentChat.parentMessageIndex + 1} в{' '}
+            <button
+              className="internal-link"
+              onClick={() => setCurrentChatId(currentChat.parentId!)}
+            >
+              {store.chats[currentChat.parentId]?.title || 'родительский чат'}
+            </button>
+          </span>
+        )}
+      </div>
+
+      {/* Messages */}
+      <div className="chat-feed" ref={feedRef}>
+        {currentChat.messages.length === 0 && (
+          <div className="chat-empty">
+            Начните разговор. Напишите сообщение ниже.
+          </div>
+        )}
+        {currentChat.messages.map((msg, index) => (
+          <div key={msg.id} className={`chat-message chat-message--${msg.role}`}>
+            <div className="message-header">
+              <span className="message-role">
+                {msg.role === 'user'
+                  ? '👤 Вы'
+                  : msg.role === 'assistant'
+                    ? '🤖 Ассистент'
+                    : '🔔 Система'}
+              </span>
+              <span className="message-time">
+                {new Date(msg.timestamp).toLocaleTimeString('ru-RU', {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </span>
+              {msg.role !== 'system' && (
+                <button
+                  className="fork-btn"
+                  onClick={() => setForkingIndex(index)}
+                  title="Создать ветку от этого сообщения"
+                >
+                  ⑂
+                </button>
+              )}
+            </div>
+            <div className="message-content">
+              <MessageContent content={msg.content} />
+            </div>
+            {forkingIndex === index && (
+              <ForkDialog
+                onConfirm={(title) => {
+                  forkChat(index, title)
+                  setForkingIndex(null)
+                }}
+                onCancel={() => setForkingIndex(null)}
+              />
+            )}
+            {/* Show fork indicators */}
+            {Object.values(store.chats)
+              .filter(
+                (c) =>
+                  c.parentId === currentChatId &&
+                  c.parentMessageIndex === index
+              )
+              .map((forkedChat) => (
+                <button
+                  key={forkedChat.id}
+                  className="fork-indicator"
+                  onClick={() => setCurrentChatId(forkedChat.id)}
+                >
+                  ↳ {forkedChat.title}
+                </button>
+              ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/ChatFeed.tsx
+++ b/src/components/chat/ChatFeed.tsx
@@ -1,16 +1,18 @@
 'use client'
 
-import { getAncestors, parseLinks } from '@/lib/chatStore'
-import React, { useEffect, useRef, useState } from 'react'
+import { getAncestors, parseLinks, splitByKeywords } from '@/lib/chatStore'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useChatContext } from './ChatProvider'
 
 function MessageContent({ content }: { content: string }) {
   const { setCurrentChatId, store } = useChatContext()
-  const parts = parseLinks(content)
+
+  // First pass: parse [[chatId|title]] links
+  const linkParts = parseLinks(content)
 
   return (
     <span>
-      {parts.map((part, i) => {
+      {linkParts.map((part, i) => {
         if (part.type === 'link' && part.chatId) {
           const exists = !!store.chats[part.chatId]
           return (
@@ -20,13 +22,89 @@ function MessageContent({ content }: { content: string }) {
               onClick={() => exists && setCurrentChatId(part.chatId!)}
               title={exists ? `Перейти: ${part.value}` : 'Чат удалён'}
             >
-              🔗 {part.value}
+              {part.value}
             </button>
           )
         }
-        return <span key={i}>{part.value}</span>
+        // Second pass: highlight keywords in plain text
+        const keywordParts = splitByKeywords(part.value, store.keywords)
+        return (
+          <React.Fragment key={i}>
+            {keywordParts.map((kp, j) => {
+              if (kp.type === 'keyword' && kp.chatId) {
+                const exists = !!store.chats[kp.chatId]
+                return (
+                  <button
+                    key={j}
+                    className={`internal-link ${!exists ? 'internal-link--dead' : ''}`}
+                    onClick={() => exists && setCurrentChatId(kp.chatId!)}
+                    title={exists ? `Перейти в чат: ${kp.value}` : 'Чат удалён'}
+                  >
+                    {kp.value}
+                  </button>
+                )
+              }
+              return <span key={j}>{kp.value}</span>
+            })}
+          </React.Fragment>
+        )
       })}
     </span>
+  )
+}
+
+function SelectionPopup({
+  x,
+  y,
+  selectedText,
+  onSubmit,
+  onClose,
+}: {
+  x: number
+  y: number
+  selectedText: string
+  onSubmit: (prompt: string) => void
+  onClose: () => void
+}) {
+  const [prompt, setPrompt] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    // Focus after a tick so the selection doesn't get cleared
+    const t = setTimeout(() => inputRef.current?.focus(), 50)
+    return () => clearTimeout(t)
+  }, [])
+
+  return (
+    <div
+      className="selection-popup"
+      style={{ left: x, top: y }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <span className="selection-popup-label">{selectedText}</span>
+      <input
+        ref={inputRef}
+        className="selection-popup-input"
+        type="text"
+        placeholder="О чём спросить..."
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && prompt.trim()) {
+            onSubmit(prompt.trim())
+          }
+          if (e.key === 'Escape') {
+            onClose()
+          }
+        }}
+      />
+      <button
+        className="selection-popup-send"
+        onClick={() => prompt.trim() && onSubmit(prompt.trim())}
+      >
+        →
+      </button>
+    </div>
   )
 }
 
@@ -66,18 +144,85 @@ function ForkDialog({
 }
 
 export function ChatFeed() {
-  const { store, currentChat, currentChatId, forkChat, setCurrentChatId, renameChat } =
-    useChatContext()
+  const {
+    store,
+    currentChat,
+    currentChatId,
+    forkChat,
+    forkFromSelection,
+    setCurrentChatId,
+    renameChat,
+  } = useChatContext()
   const feedRef = useRef<HTMLDivElement>(null)
   const [forkingIndex, setForkingIndex] = useState<number | null>(null)
   const [editingTitle, setEditingTitle] = useState(false)
   const [titleValue, setTitleValue] = useState('')
+
+  // Selection popup state
+  const [selectionPopup, setSelectionPopup] = useState<{
+    x: number
+    y: number
+    text: string
+    messageIndex: number
+  } | null>(null)
 
   useEffect(() => {
     if (feedRef.current) {
       feedRef.current.scrollTop = feedRef.current.scrollHeight
     }
   }, [currentChat?.messages.length])
+
+  // Detect text selection inside messages
+  const handleMouseUp = useCallback(() => {
+    const selection = window.getSelection()
+    if (!selection || selection.isCollapsed || !selection.toString().trim()) {
+      return
+    }
+
+    const text = selection.toString().trim()
+    if (text.length < 2 || text.length > 100) {
+      setSelectionPopup(null)
+      return
+    }
+
+    // Find which message the selection is in
+    const anchorNode = selection.anchorNode
+    if (!anchorNode) return
+
+    let messageEl: HTMLElement | null = null
+    let node: Node | null = anchorNode
+    while (node) {
+      if (node instanceof HTMLElement && node.classList.contains('chat-message')) {
+        messageEl = node
+        break
+      }
+      node = node.parentNode
+    }
+
+    if (!messageEl) return
+
+    const indexStr = messageEl.getAttribute('data-index')
+    if (indexStr === null) return
+
+    const range = selection.getRangeAt(0)
+    const rect = range.getBoundingClientRect()
+
+    setSelectionPopup({
+      x: rect.left + rect.width / 2 - 25,
+      y: rect.top - 40,
+      text,
+      messageIndex: parseInt(indexStr, 10),
+    })
+  }, [])
+
+  const handleMouseDown = useCallback(() => {
+    setSelectionPopup(null)
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => document.removeEventListener('mousedown', handleMouseDown)
+  }, [handleMouseDown])
 
   if (!currentChat) {
     return <div className="chat-feed-empty">Выберите чат</div>
@@ -92,7 +237,7 @@ export function ChatFeed() {
       <div className="chat-breadcrumbs">
         {breadcrumbs.map((chat, i) => (
           <React.Fragment key={chat.id}>
-            {i > 0 && <span className="breadcrumb-sep">→</span>}
+            {i > 0 && <span className="breadcrumb-sep">/</span>}
             <button
               className={`breadcrumb-item ${
                 chat.id === currentChatId ? 'breadcrumb-item--active' : ''
@@ -152,21 +297,25 @@ export function ChatFeed() {
       </div>
 
       {/* Messages */}
-      <div className="chat-feed" ref={feedRef}>
+      <div className="chat-feed" ref={feedRef} onMouseUp={handleMouseUp}>
         {currentChat.messages.length === 0 && (
           <div className="chat-empty">
             Начните разговор. Напишите сообщение ниже.
           </div>
         )}
         {currentChat.messages.map((msg, index) => (
-          <div key={msg.id} className={`chat-message chat-message--${msg.role}`}>
+          <div
+            key={msg.id}
+            className={`chat-message chat-message--${msg.role}`}
+            data-index={index}
+          >
             <div className="message-header">
               <span className="message-role">
                 {msg.role === 'user'
-                  ? '👤 Вы'
+                  ? 'Вы'
                   : msg.role === 'assistant'
-                    ? '🤖 Ассистент'
-                    : '🔔 Система'}
+                    ? 'Ассистент'
+                    : 'Система'}
               </span>
               <span className="message-time">
                 {new Date(msg.timestamp).toLocaleTimeString('ru-RU', {
@@ -215,6 +364,24 @@ export function ChatFeed() {
           </div>
         ))}
       </div>
+
+      {/* Selection popup */}
+      {selectionPopup && (
+        <SelectionPopup
+          x={selectionPopup.x}
+          y={selectionPopup.y}
+          selectedText={selectionPopup.text}
+          onSubmit={(prompt) => {
+            forkFromSelection(selectionPopup.text, selectionPopup.messageIndex, prompt)
+            setSelectionPopup(null)
+            window.getSelection()?.removeAllRanges()
+          }}
+          onClose={() => {
+            setSelectionPopup(null)
+            window.getSelection()?.removeAllRanges()
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useChatContext } from './ChatProvider'
+
+export function ChatInput() {
+  const [text, setText] = useState('')
+  const { addMessage, simulateAssistant, currentChat } = useChatContext()
+
+  if (!currentChat) return null
+
+  const handleSend = () => {
+    const trimmed = text.trim()
+    if (!trimmed) return
+    addMessage('user', trimmed)
+    setText('')
+    simulateAssistant(trimmed)
+  }
+
+  return (
+    <div className="chat-input-container">
+      <textarea
+        className="chat-input"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault()
+            handleSend()
+          }
+        }}
+        placeholder="Напишите сообщение... (Enter для отправки, Shift+Enter для переноса)"
+        rows={2}
+      />
+      <button className="chat-send-btn" onClick={handleSend}>
+        Отправить
+      </button>
+    </div>
+  )
+}

--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -1,0 +1,240 @@
+'use client'
+
+import {
+  Chat,
+  ChatMessage,
+  ChatStore,
+  createChat,
+  createInternalLink,
+  createMessage,
+  loadStore,
+  saveStore,
+} from '@/lib/chatStore'
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
+
+interface ChatContextType {
+  store: ChatStore
+  currentChatId: string
+  setCurrentChatId: (id: string) => void
+  currentChat: Chat | null
+  addMessage: (role: ChatMessage['role'], content: string) => void
+  forkChat: (messageIndex: number, title?: string) => string
+  createNewChat: (title: string, parentId?: string | null) => string
+  deleteChat: (chatId: string) => void
+  renameChat: (chatId: string, title: string) => void
+  simulateAssistant: (userMessage: string) => void
+}
+
+const ChatContext = createContext<ChatContextType | null>(null)
+
+export function useChatContext() {
+  const ctx = useContext(ChatContext)
+  if (!ctx) throw new Error('useChatContext must be used within ChatProvider')
+  return ctx
+}
+
+export function ChatProvider({ children }: { children: React.ReactNode }) {
+  const [store, setStore] = useState<ChatStore>(() => loadStore())
+  const [currentChatId, setCurrentChatId] = useState<string>(store.rootChatId)
+  const storeRef = useRef(store)
+  storeRef.current = store
+
+  useEffect(() => {
+    saveStore(store)
+  }, [store])
+
+  const updateStore = useCallback((updater: (s: ChatStore) => ChatStore) => {
+    setStore((prev) => {
+      const next = updater(prev)
+      return next
+    })
+  }, [])
+
+  const currentChat = store.chats[currentChatId] || null
+
+  const addMessage = useCallback(
+    (role: ChatMessage['role'], content: string) => {
+      updateStore((s) => {
+        const chat = s.chats[currentChatId]
+        if (!chat) return s
+        return {
+          ...s,
+          chats: {
+            ...s.chats,
+            [currentChatId]: {
+              ...chat,
+              messages: [...chat.messages, createMessage(role, content)],
+            },
+          },
+        }
+      })
+    },
+    [currentChatId, updateStore]
+  )
+
+  const forkChat = useCallback(
+    (messageIndex: number, title?: string): string => {
+      const parentChat = storeRef.current.chats[currentChatId]
+      if (!parentChat) return currentChatId
+
+      const inheritedMessages = parentChat.messages.slice(0, messageIndex + 1)
+      const forkTitle = title || `Ветка: ${parentChat.title}`
+      const newChat = createChat(forkTitle, currentChatId, messageIndex, inheritedMessages)
+
+      // Add a system link message in the parent chat
+      const linkMsg = createMessage(
+        'system',
+        `Создана ветка: ${createInternalLink(newChat.id, forkTitle)}`
+      )
+
+      updateStore((s) => ({
+        ...s,
+        chats: {
+          ...s.chats,
+          [newChat.id]: newChat,
+          [currentChatId]: {
+            ...s.chats[currentChatId],
+            messages: [...s.chats[currentChatId].messages, linkMsg],
+          },
+        },
+      }))
+
+      setCurrentChatId(newChat.id)
+      return newChat.id
+    },
+    [currentChatId, updateStore]
+  )
+
+  const createNewChat = useCallback(
+    (title: string, parentId: string | null = null): string => {
+      const newChat = createChat(title, parentId)
+
+      // If parent, add link in parent
+      if (parentId && storeRef.current.chats[parentId]) {
+        const linkMsg = createMessage(
+          'system',
+          `Новый чат: ${createInternalLink(newChat.id, title)}`
+        )
+        updateStore((s) => ({
+          ...s,
+          chats: {
+            ...s.chats,
+            [newChat.id]: newChat,
+            [parentId]: {
+              ...s.chats[parentId],
+              messages: [...s.chats[parentId].messages, linkMsg],
+            },
+          },
+        }))
+      } else {
+        updateStore((s) => ({
+          ...s,
+          chats: { ...s.chats, [newChat.id]: newChat },
+        }))
+      }
+
+      setCurrentChatId(newChat.id)
+      return newChat.id
+    },
+    [updateStore]
+  )
+
+  const deleteChat = useCallback(
+    (chatId: string) => {
+      if (chatId === store.rootChatId) return
+      updateStore((s) => {
+        const newChats = { ...s.chats }
+        // Delete chat and all descendants
+        const toDelete = [chatId]
+        while (toDelete.length > 0) {
+          const id = toDelete.pop()!
+          delete newChats[id]
+          Object.values(s.chats)
+            .filter((c) => c.parentId === id)
+            .forEach((c) => toDelete.push(c.id))
+        }
+        return { ...s, chats: newChats }
+      })
+      if (currentChatId === chatId) {
+        setCurrentChatId(store.rootChatId)
+      }
+    },
+    [currentChatId, store.rootChatId, updateStore]
+  )
+
+  const renameChat = useCallback(
+    (chatId: string, title: string) => {
+      updateStore((s) => ({
+        ...s,
+        chats: {
+          ...s.chats,
+          [chatId]: { ...s.chats[chatId], title },
+        },
+      }))
+    },
+    [updateStore]
+  )
+
+  const simulateAssistant = useCallback(
+    (userMessage: string) => {
+      const chat = storeRef.current.chats[currentChatId]
+      if (!chat) return
+
+      const isForked = chat.parentId !== null
+      const msgCount = chat.messages.length
+
+      let response: string
+      if (msgCount <= 1) {
+        response = isForked
+          ? `Это ветка от "${storeRef.current.chats[chat.parentId!]?.title || 'родительского чата'}". Контекст унаследован. Продолжим обсуждение "${chat.title}".\n\nО чём именно хотите поговорить в этой ветке?`
+          : `Привет! Я готов обсуждать "${userMessage}". Вы можете в любой момент создать ветку разговора, нажав на кнопку форка рядом с любым сообщением, или вставить ссылку на другой чат.`
+      } else {
+        const tips = [
+          'Кстати, вы можете форкнуть этот разговор в любом месте, чтобы исследовать альтернативную тему.',
+          'Если хотите углубиться в эту тему — создайте ветку от этого сообщения.',
+          'Интересная мысль! Можно создать отдельную ветку для детального обсуждения.',
+          'Продолжаем. Помните, что все ветки доступны в дереве навигации слева.',
+        ]
+        response = `Вы написали: "${userMessage}"\n\n${tips[msgCount % tips.length]}`
+      }
+
+      // Delayed response to simulate thinking
+      setTimeout(() => {
+        setStore((prev) => {
+          const c = prev.chats[currentChatId]
+          if (!c) return prev
+          return {
+            ...prev,
+            chats: {
+              ...prev.chats,
+              [currentChatId]: {
+                ...c,
+                messages: [...c.messages, createMessage('assistant', response)],
+              },
+            },
+          }
+        })
+      }, 500)
+    },
+    [currentChatId]
+  )
+
+  return (
+    <ChatContext.Provider
+      value={{
+        store,
+        currentChatId,
+        setCurrentChatId,
+        currentChat,
+        addMessage,
+        forkChat,
+        createNewChat,
+        deleteChat,
+        renameChat,
+        simulateAssistant,
+      }}
+    >
+      {children}
+    </ChatContext.Provider>
+  )
+}

--- a/src/components/chat/ChatProvider.tsx
+++ b/src/components/chat/ChatProvider.tsx
@@ -19,6 +19,7 @@ interface ChatContextType {
   currentChat: Chat | null
   addMessage: (role: ChatMessage['role'], content: string) => void
   forkChat: (messageIndex: number, title?: string) => string
+  forkFromSelection: (selectedText: string, messageIndex: number, prompt: string) => string
   createNewChat: (title: string, parentId?: string | null) => string
   deleteChat: (chatId: string) => void
   renameChat: (chatId: string, title: string) => void
@@ -101,6 +102,67 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
       setCurrentChatId(newChat.id)
       return newChat.id
+    },
+    [currentChatId, updateStore]
+  )
+
+  const forkFromSelection = useCallback(
+    (selectedText: string, messageIndex: number, prompt: string): string => {
+      const parentChat = storeRef.current.chats[currentChatId]
+      if (!parentChat) return currentChatId
+
+      const inheritedMessages = parentChat.messages.slice(0, messageIndex + 1)
+      const newChat = createChat(selectedText, currentChatId, messageIndex, inheritedMessages)
+
+      // Add the user's prompt as the first new message in the forked chat
+      const userMsg = createMessage('user', prompt)
+      newChat.messages.push(userMsg)
+
+      const linkMsg = createMessage(
+        'system',
+        `Создана ветка: ${createInternalLink(newChat.id, selectedText)}`
+      )
+
+      const newChatId = newChat.id
+
+      updateStore((s) => ({
+        ...s,
+        chats: {
+          ...s.chats,
+          [newChatId]: newChat,
+          [currentChatId]: {
+            ...s.chats[currentChatId],
+            messages: [...s.chats[currentChatId].messages, linkMsg],
+          },
+        },
+        keywords: {
+          ...s.keywords,
+          [selectedText]: newChatId,
+        },
+      }))
+
+      setCurrentChatId(newChatId)
+
+      // Simulate assistant response in the new chat
+      setTimeout(() => {
+        const response = `Вы спросили про "${selectedText}": "${prompt}"\n\nДавайте разберём это подробнее. Этот чат унаследовал контекст из родительского разговора, так что мы можем продолжить с того места, где остановились.`
+        setStore((prev) => {
+          const c = prev.chats[newChatId]
+          if (!c) return prev
+          return {
+            ...prev,
+            chats: {
+              ...prev.chats,
+              [newChatId]: {
+                ...c,
+                messages: [...c.messages, createMessage('assistant', response)],
+              },
+            },
+          }
+        })
+      }, 500)
+
+      return newChatId
     },
     [currentChatId, updateStore]
   )
@@ -228,6 +290,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
         currentChat,
         addMessage,
         forkChat,
+        forkFromSelection,
         createNewChat,
         deleteChat,
         renameChat,

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { Chat, getChildren } from '@/lib/chatStore'
+import React, { useState } from 'react'
+import { useChatContext } from './ChatProvider'
+
+function TreeNode({ chat, depth = 0 }: { chat: Chat; depth?: number }) {
+  const { store, currentChatId, setCurrentChatId, deleteChat } = useChatContext()
+  const children = getChildren(store, chat.id)
+  const [expanded, setExpanded] = useState(true)
+  const isActive = currentChatId === chat.id
+  const hasChildren = children.length > 0
+
+  return (
+    <div>
+      <div
+        className={`tree-node ${isActive ? 'tree-node--active' : ''}`}
+        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      >
+        <button
+          className="tree-toggle"
+          onClick={() => setExpanded(!expanded)}
+          style={{ visibility: hasChildren ? 'visible' : 'hidden' }}
+        >
+          {expanded ? '▾' : '▸'}
+        </button>
+        <button
+          className="tree-label"
+          onClick={() => setCurrentChatId(chat.id)}
+          title={chat.title}
+        >
+          <span className="tree-icon">{chat.parentId ? '↳' : '◉'}</span>
+          <span className="tree-title">{chat.title}</span>
+        </button>
+        {chat.parentId && (
+          <button
+            className="tree-delete"
+            onClick={(e) => {
+              e.stopPropagation()
+              deleteChat(chat.id)
+            }}
+            title="Удалить"
+          >
+            ×
+          </button>
+        )}
+      </div>
+      {expanded &&
+        children
+          .sort((a, b) => a.createdAt - b.createdAt)
+          .map((child) => (
+            <TreeNode key={child.id} chat={child} depth={depth + 1} />
+          ))}
+    </div>
+  )
+}
+
+export function ChatSidebar() {
+  const { store, createNewChat, currentChatId } = useChatContext()
+  const rootChat = store.chats[store.rootChatId]
+
+  return (
+    <div className="chat-sidebar">
+      <div className="sidebar-header">
+        <h2>Чаты</h2>
+        <button
+          className="new-chat-btn"
+          onClick={() => createNewChat('Новый чат', currentChatId)}
+          title="Новый дочерний чат"
+        >
+          +
+        </button>
+      </div>
+      <div className="sidebar-tree">
+        {rootChat && <TreeNode chat={rootChat} />}
+      </div>
+      <div className="sidebar-footer">
+        <span className="sidebar-count">
+          {Object.keys(store.chats).length} чатов
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/chatStore.ts
+++ b/src/lib/chatStore.ts
@@ -1,0 +1,121 @@
+export interface ChatMessage {
+  id: string
+  role: 'user' | 'assistant' | 'system'
+  content: string
+  timestamp: number
+}
+
+export interface Chat {
+  id: string
+  title: string
+  parentId: string | null
+  parentMessageIndex: number | null // fork point in parent chat
+  messages: ChatMessage[]
+  createdAt: number
+}
+
+export interface ChatStore {
+  chats: Record<string, Chat>
+  rootChatId: string
+}
+
+const STORAGE_KEY = 'chat-links-store'
+
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 10) + Date.now().toString(36)
+}
+
+export function createMessage(
+  role: ChatMessage['role'],
+  content: string
+): ChatMessage {
+  return {
+    id: generateId(),
+    role,
+    content,
+    timestamp: Date.now(),
+  }
+}
+
+export function createChat(
+  title: string,
+  parentId: string | null = null,
+  parentMessageIndex: number | null = null,
+  inheritedMessages: ChatMessage[] = []
+): Chat {
+  return {
+    id: generateId(),
+    title,
+    parentId,
+    parentMessageIndex,
+    messages: inheritedMessages.map((m) => ({ ...m, id: generateId() })),
+    createdAt: Date.now(),
+  }
+}
+
+export function loadStore(): ChatStore {
+  if (typeof window === 'undefined') {
+    const rootChat = createChat('Главный чат')
+    return { chats: { [rootChat.id]: rootChat }, rootChatId: rootChat.id }
+  }
+  try {
+    const data = localStorage.getItem(STORAGE_KEY)
+    if (data) {
+      return JSON.parse(data)
+    }
+  } catch {
+    // ignore
+  }
+  const rootChat = createChat('Главный чат')
+  return { chats: { [rootChat.id]: rootChat }, rootChatId: rootChat.id }
+}
+
+export function saveStore(store: ChatStore): void {
+  if (typeof window === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(store))
+}
+
+export function getChildren(
+  store: ChatStore,
+  chatId: string
+): Chat[] {
+  return Object.values(store.chats).filter((c) => c.parentId === chatId)
+}
+
+export function getAncestors(store: ChatStore, chatId: string): Chat[] {
+  const ancestors: Chat[] = []
+  let current = store.chats[chatId]
+  while (current?.parentId) {
+    current = store.chats[current.parentId]
+    if (current) ancestors.unshift(current)
+  }
+  return ancestors
+}
+
+// Parse internal links: [[chatId|display text]]
+export function parseLinks(
+  content: string
+): Array<{ type: 'text' | 'link'; value: string; chatId?: string }> {
+  const parts: Array<{ type: 'text' | 'link'; value: string; chatId?: string }> = []
+  const regex = /\[\[([^\]|]+)\|([^\]]+)\]\]/g
+  let lastIndex = 0
+  let match
+
+  while ((match = regex.exec(content)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', value: content.slice(lastIndex, match.index) })
+    }
+    parts.push({ type: 'link', value: match[2], chatId: match[1] })
+    lastIndex = regex.lastIndex
+  }
+
+  if (lastIndex < content.length) {
+    parts.push({ type: 'text', value: content.slice(lastIndex) })
+  }
+
+  return parts
+}
+
+export function createInternalLink(chatId: string, title: string): string {
+  return `[[${chatId}|${title}]]`
+}

--- a/src/lib/chatStore.ts
+++ b/src/lib/chatStore.ts
@@ -17,6 +17,8 @@ export interface Chat {
 export interface ChatStore {
   chats: Record<string, Chat>
   rootChatId: string
+  // keyword → chatId: selected text becomes a link everywhere
+  keywords: Record<string, string>
 }
 
 const STORAGE_KEY = 'chat-links-store'
@@ -56,18 +58,20 @@ export function createChat(
 export function loadStore(): ChatStore {
   if (typeof window === 'undefined') {
     const rootChat = createChat('Главный чат')
-    return { chats: { [rootChat.id]: rootChat }, rootChatId: rootChat.id }
+    return { chats: { [rootChat.id]: rootChat }, rootChatId: rootChat.id, keywords: {} }
   }
   try {
     const data = localStorage.getItem(STORAGE_KEY)
     if (data) {
-      return JSON.parse(data)
+      const parsed = JSON.parse(data)
+      if (!parsed.keywords) parsed.keywords = {}
+      return parsed
     }
   } catch {
     // ignore
   }
   const rootChat = createChat('Главный чат')
-  return { chats: { [rootChat.id]: rootChat }, rootChatId: rootChat.id }
+  return { chats: { [rootChat.id]: rootChat }, rootChatId: rootChat.id, keywords: {} }
 }
 
 export function saveStore(store: ChatStore): void {
@@ -118,4 +122,40 @@ export function parseLinks(
 
 export function createInternalLink(chatId: string, title: string): string {
   return `[[${chatId}|${title}]]`
+}
+
+// Split text by keywords, returning segments with keyword matches
+export function splitByKeywords(
+  text: string,
+  keywords: Record<string, string>
+): Array<{ type: 'text' | 'keyword'; value: string; chatId?: string }> {
+  const entries = Object.entries(keywords)
+  if (entries.length === 0) return [{ type: 'text', value: text }]
+
+  // Sort by length descending so longer keywords match first
+  entries.sort((a, b) => b[0].length - a[0].length)
+
+  const escaped = entries.map(([kw]) => kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const pattern = new RegExp(`(${escaped.join('|')})`, 'gi')
+
+  const parts: Array<{ type: 'text' | 'keyword'; value: string; chatId?: string }> = []
+  let lastIndex = 0
+  let match
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', value: text.slice(lastIndex, match.index) })
+    }
+    const matched = match[1]
+    // Find the keyword (case-insensitive lookup)
+    const entry = entries.find(([kw]) => kw.toLowerCase() === matched.toLowerCase())
+    parts.push({ type: 'keyword', value: matched, chatId: entry?.[1] })
+    lastIndex = pattern.lastIndex
+  }
+
+  if (lastIndex < text.length) {
+    parts.push({ type: 'text', value: text.slice(lastIndex) })
+  }
+
+  return parts
 }


### PR DESCRIPTION
Prototype chat shell for LLMs with:
- Internal hyperlinks between chats ([[chatId|title]] syntax)
- Fork conversations from any message point with context inheritance
- Tree navigation sidebar showing chat hierarchy
- Breadcrumb navigation for ancestor chain
- Chat rename, delete, and creation
- localStorage persistence
- Simulated assistant responses

Accessible at /chat route.

https://claude.ai/code/session_01CWaVnejcJUSn33eYVhkkQ6